### PR TITLE
(feature) re-structure Playwright setup a bit

### DIFF
--- a/template/playwright.config.ts
+++ b/template/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-    testDir: './test/integration',
+    testDir: './test/spec',
 
     /* Run tests in files in parallel */
     fullyParallel: true,

--- a/template/test/pom/AppPage.ts
+++ b/template/test/pom/AppPage.ts
@@ -1,6 +1,4 @@
-import { type Page, test as base } from '@playwright/test';
-
-export const BASE_URL = 'http://localhost:3000/#/';
+import type { Page } from '@playwright/test';
 
 /**
  * Creates a "page object model" (POM).
@@ -14,28 +12,20 @@ export const appPage = (page: Page) => {
     const body = page.locator('.ApplicationLayoutBody');
     const locationMenu = page.locator('.ModuleNavigation-dropdown');
     const actionBarItems = page.locator('.ActionBarItemIcon');
+    const releaseNotes = page.getByText('Release notes');
 
     const open = async (queryParams: Record<string, string> = {}) => {
         const search = new URLSearchParams(queryParams).toString();
-        await page.goto(`${BASE_URL}${search ? `?${search}` : ''}`);
+        if (search) {
+            await page.goto(`/?${search}`);
+        } else {
+            await page.goto('/');
+        }
     };
 
     const openServiceInfo = async () => {
         await actionBarItems.first().click();
     };
 
-    return { page, body, locationMenu, actionBarItems, open, openServiceInfo };
+    return { page, body, locationMenu, actionBarItems, releaseNotes, open, openServiceInfo };
 };
-
-export type AppPage = ReturnType<typeof appPage>;
-
-/**
- * Extends the default Playwright `test` function with a "fixture".
- *
- * This allows specs to directly use the POM instead of having to create it every single time.
- *
- * @see https://playwright.dev/docs/test-fixtures
- */
-export const test = base.extend<{ appPage: AppPage }>({
-    appPage: async ({ page }, use) => await use(appPage(page)),
-});

--- a/template/test/spec/AppBasics.spec.ts
+++ b/template/test/spec/AppBasics.spec.ts
@@ -1,11 +1,10 @@
 import { expect } from '@playwright/test';
-
-import { test, BASE_URL } from './AppPage';
+import { test } from '../testSetup';
 
 test.describe('App basic functionality', () => {
     test('base url', async ({ appPage, page }) => {
         await appPage.open();
-        expect(page.url()).toBe(BASE_URL);
+        expect(new URL(page.url()).pathname).toBe('/');
     });
 
     test('deep-linking', async ({ appPage, page }) => {
@@ -25,7 +24,8 @@ test.describe('App basic functionality', () => {
 
     test('rendering the service info', async ({ appPage, page }) => {
         await appPage.open();
+        await expect(appPage.releaseNotes).not.toBeVisible();
         await appPage.openServiceInfo();
-        await expect(page.getByText('Release notes')).toBeVisible();
+        await expect(appPage.releaseNotes).toBeVisible();
     });
 });

--- a/template/test/testSetup.ts
+++ b/template/test/testSetup.ts
@@ -1,0 +1,13 @@
+import { test as base } from '@playwright/test';
+import { appPage } from './pom/AppPage';
+
+/**
+ * Defines the names and types of all POMs.
+ */
+type POMs = {
+    appPage: ReturnType<typeof appPage>;
+};
+
+export const test = base.extend<POMs>({
+    appPage: async ({ page }, use) => await use(appPage(page)),
+});


### PR DESCRIPTION
- one central testSetup file that provides the extended test function with all POMs as fixtures
- dedicated directories for POMs and specs
- no more hard-coded BASE_URL (it's set by Playwright, anyway)
- tiny refactoring: move "Release notes" locator into POM
- no more need to explicitly define & export the POM type - it's only used in the testSetup file, and can be inferred there, anyway