### PR TITLE
(fix) run typescript compiler when building the application to ensure typechecking

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "start": "vite",
-        "build": "vite build",
+        "build": "tsc && vite build",
         "postbuild": "rimraf ./build/mockServiceWorker.js",
         "preview": "vite preview",
         "test": "vitest run",


### PR DESCRIPTION
This reduce the risk of shipping code to prod, without running the typescript compiler