### PR TITLE
(feature) Log warnings about duplicate keys from different translation files

### DIFF
--- a/template/mergeTranslations.js
+++ b/template/mergeTranslations.js
@@ -27,6 +27,12 @@ for (const [locale, files] of filesByLocales) {
     const contents = await Promise.all(promises);
 
     const mergedContent = contents.reduce((outgoingFile, content) => {
+        // find duplicates
+        for (const key of Object.keys(content)) {
+            if (outgoingFile[key]) {
+                console.warn(`Duplicate key '${key}' found in locale ${locale}`);
+            }
+        }
         Object.assign(outgoingFile, content);
         return outgoingFile;
     }, {});


### PR DESCRIPTION
We accidentally pushed translations from the glossary / common translations to our project. This log message helps to detect such duplicates.